### PR TITLE
nginxのプロセスがなかったらcronでstartするようにシェルスクリプトを作成

### DIFF
--- a/centos7/cron
+++ b/centos7/cron
@@ -1,0 +1,1 @@
+*/1 * * * * sh /servicecheck.sh

--- a/centos7/servicecheck.sh
+++ b/centos7/servicecheck.sh
@@ -1,6 +1,9 @@
-services=("nginx")
+#!/bin/bash
+# */1 * * * * sh /home/servicecheck.sh
 
-count=`ps aux | grep $services | grep -v grep | wc -l`
+PROCESSNAME01=nginx
+
+count=`pgrep $PROCESSNAME01 | wc -l`
 if [ $count == 0 ]; then
  echo "nginxのプロセスが死んでいるので起動します"
  sudo systemctl start nginx

--- a/centos7/servicecheck.sh
+++ b/centos7/servicecheck.sh
@@ -1,0 +1,10 @@
+services=("nginx")
+
+count=`ps aux | grep $services | grep -v grep | wc -l`
+if [ $count == 0 ]; then
+ echo "nginxのプロセスが死んでいるので起動します"
+ sudo systemctl start nginx
+else
+ echo "nginxは生きている!"
+fi
+


### PR DESCRIPTION
```
services=("nginx")

count=`ps aux | grep $services | grep -v grep | wc -l`
if [ $count == 0 ]; then
 echo "nginxのプロセスが死んでいるので起動します"
 sudo systemctl start nginx
else
 echo "nginxは生きている!"
fi
```
起動シェルスクリプトのコード。ps auxコマンドでプロセス一覧を表示。grep $servicesで変数内のプロセスの名前で検索。するとnginxという単語が入った実行中のプロセス一覧が帰ってくる。

```
root      5915  0.0  0.1  46440   968 ?        Ss   07:26   0:00 nginx: master process /usr/sbin/nginx -c /etc/nginx/nginx.conf
nginx     5916  0.0  0.3  46848  1928 ?        S    07:26   0:00 nginx: worker process
root      5963  0.0  0.1  12520   984 pts/0    S+   08:08   0:00 grep --color=auto nginx
```

このままだとnginxを検索したプロセス(上から3番目)も混ざってしまうので、除去する必要がある。

```
ps aux | grep $services | grep -v grep | wc -l
```

grep -v grepでgrepが含まれない行を選択。wc -lで行数のみを表示。

```
*/1 * * * * sh /servicecheck.sh
```

cronのコード。1分おきにシェルスクリプトを実行して、nginxのプロセスを監視してくれる。

- grepでよく使うパイプライン「|」について
コマンドの実行結果を次のコマンドに渡すことができる。例えば下記なんかだと、ps auxで実行中のプロセス一覧を取得したのち、結果をgrep $servicesに渡し、その中で検索を行う。

```
ps aux | grep $services
```
